### PR TITLE
PDLA::GIS and PDLA::Transform compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ my %common_reqs = (
 );
 
 my %WriteMakefileArgs = (
-    "ABSTRACT" => "Alien package for the PROJ library",
+    "ABSTRACT" => "Alien package for version 4 of the PROJ library",
     "AUTHOR"   => 'Shawn Laffan <shawnlaffan@gmail.com>',
     "NAME"     => "Alien::Proj4",
     "VERSION_FROM" => "lib/Alien/Proj4.pm",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# perl-alien-proj4
-Perl Alien package to compile the [Proj library](https://proj4.org/).
+# Alien::Proj4
+Perl Alien package to compile version 4 of the [Proj library](https://proj4.org/).
 
 [![Build Status](https://travis-ci.org/shawnlaffan/perl-alien-proj4.svg?branch=master)](https://travis-ci.org/shawnlaffan/perl-alien-proj4)
 
 [![Build status](https://ci.appveyor.com/api/projects/status/3lv9qu9ea2ex3p5d?svg=true)](https://ci.appveyor.com/project/shawnlaffan/perl-alien-proj4)
 
-[![CPAN version](https://badge.fury.io/pl/Alien-proj.svg)](http://badge.fury.io/pl/Alien-proj)
+[![CPAN version](https://badge.fury.io/pl/Alien-Proj4.svg)](http://badge.fury.io/pl/Alien-Proj4)
 

--- a/lib/Alien/Proj4.pm
+++ b/lib/Alien/Proj4.pm
@@ -19,10 +19,12 @@ sub import {
 
 sub default_lib {
     my ($class) = @_;
+    return;
 }
 
 sub default_inc {
     my ($class) = @_;
+    return;
 }
 
 sub libflags {

--- a/lib/Alien/Proj4.pm
+++ b/lib/Alien/Proj4.pm
@@ -6,7 +6,41 @@ use parent qw( Alien::Base );
 
 our $VERSION = '2.019106';
 
+#  most of these are for compat with PDLA Makefiles and the like 
 sub installed {1}
+
+my @lib_locations;
+my @inc_locations;
+sub import {
+    my ($class, $lib, $inc) = @_;
+    @lib_locations = @$lib if $lib and @$lib;
+    @inc_locations = @$inc if $inc and @$inc;
+}
+
+sub default_lib {
+    my ($class) = @_;
+}
+
+sub default_inc {
+    my ($class) = @_;
+}
+
+sub libflags {
+    my ($class) = @_;
+    my $flags;
+    foreach my $lib (@lib_locations, $class->libs) {
+        $flags .= "-L$lib ";  #  spaces in paths??
+    }
+}
+
+sub incflags {
+    my ($class) = @_;
+    my $flags = $class->cflags;
+    #  append user added dirs
+    #  a somewhat underhanded approach
+    $flags .= "-I$_" foreach @inc_locations;
+    return $flags;
+}
 
 # dup of code currently in PDLA::GIS::Proj
 sub load_projection_descriptions {

--- a/lib/Alien/Proj4.pm
+++ b/lib/Alien/Proj4.pm
@@ -6,41 +6,32 @@ use parent qw( Alien::Base );
 
 our $VERSION = '2.019106';
 
-#  most of these are for compat with PDLA Makefiles and the like 
+#  most of the following are for compat with PDLA Makefiles
+#  and should not be used by other code
 sub installed {1}
 
-my @lib_locations;
-my @inc_locations;
 sub import {
-    my ($class, $lib, $inc) = @_;
-    @lib_locations = @$lib if $lib and @$lib;
-    @inc_locations = @$inc if $inc and @$inc;
+    #  do nothing
+    return;
 }
 
 sub default_lib {
-    my ($class) = @_;
     return;
 }
 
 sub default_inc {
-    my ($class) = @_;
     return;
 }
 
 sub libflags {
     my ($class) = @_;
-    my $flags;
-    foreach my $lib (@lib_locations, $class->libs) {
-        $flags .= "-L$lib ";  #  spaces in paths??
-    }
+    my $flags = join ' ',  $class->libs;
+    return $flags;
 }
 
 sub incflags {
     my ($class) = @_;
     my $flags = $class->cflags;
-    #  append user added dirs
-    #  a somewhat underhanded approach
-    $flags .= "-I$_" foreach @inc_locations;
     return $flags;
 }
 


### PR DESCRIPTION
Adds methods so the makefiles for PDLA::GIS and PDLA::Transform will function using external Alien::Proj4.  

Needed for PDLPorters/pdla-rest#21 to work.