### PR TITLE
diag error in test, simplify hash dump

### DIFF
--- a/t/02-use.t
+++ b/t/02-use.t
@@ -28,10 +28,12 @@ diag "no proj bin dir found via bin_dir method\n" if not @bin;
 my $info = eval {
     Alien::Proj4->load_projection_information
 };
-is $@, '', 'got projection information without error';
+my $e = $@;
+diag $e if $e;
+is $e, '', 'got projection information without error';
 #  could check some of the hash contents, but not sure it's worth it
 is ref $info, 'HASH', 'projection info is a hash ref';
-diag explain $info;
+diag explain [sort keys %$info];
 
 TODO: {
     local $TODO = 'leftover from gdal, not sure we even need it given the planned usage';

--- a/t/02-use.t
+++ b/t/02-use.t
@@ -28,12 +28,10 @@ diag "no proj bin dir found via bin_dir method\n" if not @bin;
 my $info = eval {
     Alien::Proj4->load_projection_information
 };
-my $e = $@;
-diag $e if $e;
-is $e, '', 'got projection information without error';
+is $@, '', 'got projection information without error';
 #  could check some of the hash contents, but not sure it's worth it
-is ref $info, 'HASH', 'projection info is a hash ref';
-diag explain [sort keys %$info];
+is ref $info, 'HASH', 'projection info is a hash ref'
+  or diag explain $info;
 
 TODO: {
     local $TODO = 'leftover from gdal, not sure we even need it given the planned usage';


### PR DESCRIPTION
The hash is massive when it works, and it will be empty when load_projection_information fails.

Better to diag the error message, which is probably derived from the Inline call in load_projection_descriptions.
